### PR TITLE
Return obsoletes to the graph

### DIFF
--- a/kg_phenio/transform_utils/phenio/phenio_transform.py
+++ b/kg_phenio/transform_utils/phenio/phenio_transform.py
@@ -129,6 +129,6 @@ class PhenioTransform(Transform):
                     output_format='tsv',
                     stream=True)
 
-        remove_obsoletes(os.path.join(self.output_dir, name + "_nodes.tsv"),
-                        os.path.join(self.output_dir, name + "_edges.tsv"))
+        # remove_obsoletes(os.path.join(self.output_dir, name + "_nodes.tsv"),
+        #                os.path.join(self.output_dir, name + "_edges.tsv"))
 


### PR DESCRIPTION
Obsolete nodes have value for the Monarch UI and potentially other downstream use cases.
This PR brings them back.