### PR TITLE
Fix for PHENIO transform

### DIFF
--- a/kg_phenio/transform_utils/phenio/phenio_transform.py
+++ b/kg_phenio/transform_utils/phenio/phenio_transform.py
@@ -69,9 +69,7 @@ class PhenioTransform(Transform):
 
         print(f"Parsing {data_file}")
 
-        data_filename = os.path.basename(data_file)
-
-        transform(inputs=[data_filename],
+        transform(inputs=[data_file],
                   input_format='owl',
                   output=os.path.join(self.output_dir, name),
                   output_format='tsv',


### PR DESCRIPTION
Transform was using the incorrect input file path for KGX operations.