### PR TITLE
Fix issues with call to universalizer

### DIFF
--- a/kg_phenio/normalize.py
+++ b/kg_phenio/normalize.py
@@ -17,7 +17,7 @@ def normalize() -> None:
                               compressed=False,
                               maps=[],
                               update_categories=True,
-                              contexts=[],
+                              contexts=["obo", "bioregistry.upper"],
                               namespace_cat_map="",
                               oak_lookup=False)
     print("Complete.")

--- a/kg_phenio/normalize.py
+++ b/kg_phenio/normalize.py
@@ -13,9 +13,11 @@ def normalize() -> None:
 
     """
     print("Normalizing nodes and categories...")
-    clean_and_normalize_graph(input_path="data/merged/",
+    clean_and_normalize_graph(filepath="data/merged/",
                               compressed=False,
                               maps=[],
                               update_categories=True,
+                              contexts=[],
+                              namespace_cat_map="",
                               oak_lookup=False)
     print("Complete.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -193,14 +193,14 @@ tox = "*"
 
 [[package]]
 name = "boto3"
-version = "1.26.28"
+version = "1.26.29"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.29.28,<1.30.0"
+botocore = ">=1.29.29,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -209,7 +209,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.28"
+version = "1.29.29"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -1289,7 +1289,7 @@ viz = ["pygraphviz"]
 
 [[package]]
 name = "oaklib"
-version = "0.1.62"
+version = "0.1.63"
 description = "Ontology Access Kit: Python library for common ontology operations over a variety of backends"
 category = "main"
 optional = false
@@ -2260,7 +2260,7 @@ url = ["furl (>=0.4.1)"]
 
 [[package]]
 name = "sssom"
-version = "0.3.17"
+version = "0.3.18"
 description = "Operations on SSSOM mapping tables"
 category = "main"
 optional = false
@@ -2708,12 +2708,12 @@ bmt = [
     {file = "bmt-0.8.12.tar.gz", hash = "sha256:b1f14e87b4f45181ffbb882ebc8bc7400298a7ce8e94cc8b80ba2a319010c47d"},
 ]
 boto3 = [
-    {file = "boto3-1.26.28-py3-none-any.whl", hash = "sha256:548081a0f8854bb2eea1e368ab29945478105f56989546f653c75528dcb07d88"},
-    {file = "boto3-1.26.28.tar.gz", hash = "sha256:53badfc5f145b8a3f9117512b41bc5a64db1cce1b549061d8edba68909e63fdf"},
+    {file = "boto3-1.26.29-py3-none-any.whl", hash = "sha256:2e5e80daae3873185b046d1fabc13676aea519e891faf4f27ca71d287bc26039"},
+    {file = "boto3-1.26.29.tar.gz", hash = "sha256:4fb4a0ce2679e5dc1719441192b45687654201d5de76224f2c376b689c9ed4aa"},
 ]
 botocore = [
-    {file = "botocore-1.29.28-py3-none-any.whl", hash = "sha256:982732e7ed65cb6ed11ea3ce0e32dff2bcd465836c32376154f0802aa0a112c7"},
-    {file = "botocore-1.29.28.tar.gz", hash = "sha256:f0b8bb976e368dea20a960b47169e31fc0828feb6f0b9f59f1e5be8d08919b10"},
+    {file = "botocore-1.29.29-py3-none-any.whl", hash = "sha256:dca2daf108aae6c847d8ec99b7e918b46ae81713bf70b2199ab94627faf935a1"},
+    {file = "botocore-1.29.29.tar.gz", hash = "sha256:97a6d059e688ff9caa7c0a4e30cc58fa27be8bf3347578ce7c62fb808380fb55"},
 ]
 cachetools = [
     {file = "cachetools-5.2.0-py3-none-any.whl", hash = "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"},
@@ -3464,8 +3464,8 @@ nxontology = [
     {file = "nxontology-0.4.1.tar.gz", hash = "sha256:8f1e5d6d7787542e9414be4ae34bb09e369dbaf2d6c646bba2d18b122c083d44"},
 ]
 oaklib = [
-    {file = "oaklib-0.1.62-py3-none-any.whl", hash = "sha256:e62ec278e6297a7258704530f831bd879612f97a748907f8202320b8a535a89a"},
-    {file = "oaklib-0.1.62.tar.gz", hash = "sha256:94e4ae855788fab1802220100c30cf9e6f958a2d967e8f39e7f3a8d6e8c12936"},
+    {file = "oaklib-0.1.63-py3-none-any.whl", hash = "sha256:4ef863a5db853bf69b2c786bf97e49fa105e9ccf7eeeed1d353e9db9fbac3653"},
+    {file = "oaklib-0.1.63.tar.gz", hash = "sha256:a5cdf47dda1648eeb120dbf87952aab6dd0c878f1d8c0127bbc7e0b806197614"},
 ]
 ols-client = [
     {file = "ols_client-0.1.2-py3-none-any.whl", hash = "sha256:880a41aa99fd1dbcda95f408356e1c4307ad7c34dfa75c959b54973c85d9fa6e"},
@@ -4049,7 +4049,7 @@ sqlalchemy-utils = [
     {file = "SQLAlchemy_Utils-0.38.3-py3-none-any.whl", hash = "sha256:5c13b5d08adfaa85f3d4e8ec09a75136216fad41346980d02974a70a77988bf9"},
 ]
 sssom = [
-    {file = "sssom-0.3.17.tar.gz", hash = "sha256:111a452489a3f53e4b0b014e40822178a4730b3564df505ae8067ad39f62d324"},
+    {file = "sssom-0.3.18.tar.gz", hash = "sha256:661e145adfb58142367b936ff1284b784b62f36345cbc6698d8ca618deb51d37"},
 ]
 sssom-schema = [
     {file = "sssom-schema-0.9.4.tar.gz", hash = "sha256:2ecb7d0d126f8b36943ed3db0cdc76526a52742ace20124d5214171cf7935908"},


### PR DESCRIPTION
Repairs for calling `clean_and_normalize_graph`, plus the other required params, including the prefixmaps contexts to use.
For now, these are `["obo", "bioregistry.upper"]`