### PR TITLE
Switch to explicit looping in koza

### DIFF
--- a/kg_phenio/transform_utils/phenio/phenio_node_sources.py
+++ b/kg_phenio/transform_utils/phenio/phenio_node_sources.py
@@ -9,9 +9,7 @@ source_name = "phenio_node_sources"
 SYNONYM = "synonym"
 
 koza_app = get_koza_app(source_name)
-row = koza_app.get_row()
 
-valid = True
 
 # This transform is for enriching PHENIO-derived nodes
 # with Biolink-compliant knowledge sources,
@@ -106,37 +104,40 @@ bad_prefixes = ["dc", "http", "https", "DATA", "WD_Entity", "WD_Prop"]
 
 primary_knowledge_source = "infores:unknown"
 
-node_curie_prefix = (str(row["id"]).split(":"))[0]
+while (row := koza_app.get_row()) is not None:
+    valid = True
 
-# The category tells us which class to use.
-# Some categories won't fit the model and need
-# to be remapped.
-remap_cats = {
-    "OntologyClass": "NamedThing",
-    "ChemicalSubstance": "ChemicalEntity",
-    "SequenceFeature": "SequenceVariant",
-}
-category_name = (str(row["category"]).split(":"))[1]
-if category_name in remap_cats:
-    category_name = remap_cats[category_name]
-NodeClass = getattr(importlib.import_module("biolink.model"), category_name)
+    node_curie_prefix = (str(row["id"]).split(":"))[0]
 
-# TODO: make this more specific, as it won't always be true
-if node_curie_prefix not in bad_prefixes:
-    infores = infores_sources[node_curie_prefix]
-    primary_knowledge_source = f"infores:{infores}"
+    # The category tells us which class to use.
+    # Some categories won't fit the model and need
+    # to be remapped.
+    remap_cats = {
+        "OntologyClass": "NamedThing",
+        "ChemicalSubstance": "ChemicalEntity",
+        "SequenceFeature": "SequenceVariant",
+    }
+    category_name = (str(row["category"]).split(":"))[1]
+    if category_name in remap_cats:
+        category_name = remap_cats[category_name]
+    NodeClass = getattr(importlib.import_module("biolink.model"), category_name)
 
-# Association
-if valid:
-    node = NodeClass(
-        id=row["id"],
-        category=row["category"],
-        name=row["name"],
-        description=row["description"],
-        provided_by=primary_knowledge_source,
-    )
-    all_slots = list(node.__dict__.keys())
-    if row[SYNONYM] and SYNONYM in all_slots:
-        node.synonym = (row["synonym"]).split("|")
+    # TODO: make this more specific, as it won't always be true
+    if node_curie_prefix not in bad_prefixes:
+        infores = infores_sources[node_curie_prefix]
+        primary_knowledge_source = f"infores:{infores}"
 
-    koza_app.write(node)
+    # Association
+    if valid:
+        node = NodeClass(
+            id=row["id"],
+            category=row["category"],
+            name=row["name"],
+            description=row["description"],
+            provided_by=primary_knowledge_source,
+        )
+        all_slots = list(node.__dict__.keys())
+        if row[SYNONYM] and SYNONYM in all_slots:
+            node.synonym = (row["synonym"]).split("|")
+
+        koza_app.write(node)


### PR DESCRIPTION
Adds one level of nesting to use explicit looping, which skips some importlib overhead that happens on each row otherwise
