### PR TITLE
Emit kg-phenio release metadata (kozahub-metadata-schema)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,6 +133,14 @@ pipeline {
             }
         }
 
+        stage('Metadata') {
+            steps {
+                dir('./gitrepo') {
+                    sh 'uv run python scripts/write_metadata.py'
+                }
+            }
+        }
+
         stage('Publish') {
             steps {
                 dir('./gitrepo') {
@@ -168,6 +176,7 @@ pipeline {
                                 sh 'mkdir $BUILDSTARTDATE/'
                                 // sh 'cp -p data/merged/${MERGEDKGNAME_BASE}.nt.gz $BUILDSTARTDATE/${MERGEDKGNAME_BASE}.nt.gz'
                                 sh 'cp -p merged-kg.tar.gz $BUILDSTARTDATE/${MERGEDKGNAME_BASE}.tar.gz'
+                                sh 'cp -p output/release-metadata.yaml $BUILDSTARTDATE/release-metadata.yaml'
 
                                 // transformed data
                                 sh 'rm -fr data/transformed/.gitkeep'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     # pkg_resources. (Poetry used to bundle setuptools implicitly; uv
     # doesn't, so declare it explicitly.)
     "setuptools<80",
+    "kozahub-metadata-schema",
 ]
 
 [dependency-groups]
@@ -36,6 +37,9 @@ dev = [
     "parameterized>=0.8.1",
     "ruff>=0.7",
 ]
+
+[tool.uv.sources]
+kozahub-metadata-schema = { git = "https://github.com/monarch-initiative/kozahub-metadata-schema.git", branch = "main" }
 
 [tool.ruff]
 line-length = 100

--- a/run.py
+++ b/run.py
@@ -1,5 +1,9 @@
 """Run script."""
 
+import subprocess
+import sys
+from pathlib import Path
+
 import click
 
 from kg_phenio import download as kg_download
@@ -94,6 +98,18 @@ def merge(yaml: str, processes: int) -> None:
 
     load_and_merge(yaml, processes)
     normalize()
+
+
+@cli.command()
+def metadata() -> None:
+    """Emit output/release-metadata.yaml describing this kg-phenio build.
+
+    Wraps `scripts/write_metadata.py` so the kozahub-metadata-schema receipt
+    is produced as part of a local `python run.py` workflow, not just under
+    Jenkins. Reads versions.py for the upstream source list.
+    """
+    script = Path(__file__).resolve().parent / "scripts" / "write_metadata.py"
+    subprocess.run([sys.executable, str(script)], check=True)
 
 
 if __name__ == "__main__":

--- a/scripts/write_metadata.py
+++ b/scripts/write_metadata.py
@@ -1,0 +1,36 @@
+"""Emit `output/release-metadata.yaml` for kg-phenio (kozahub-metadata-schema)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parents[1]
+# Import versions.py from the repo root without triggering kg_phenio/__init__.py.
+sys.path.insert(0, str(REPO_DIR))
+
+from kozahub_metadata_schema import write_metadata  # noqa: E402
+
+from versions import get_source_versions  # noqa: E402
+
+
+def transform_files() -> list[Path]:
+    """Files whose contents go into transform_version (kg-phenio's code + configs)."""
+    src_dir = REPO_DIR / "kg_phenio"
+    py_files = sorted(src_dir.rglob("*.py"))
+    config_files = [REPO_DIR / "versions.py", REPO_DIR / "merge.yaml", REPO_DIR / "download.yaml"]
+    return py_files + [p for p in config_files if p.is_file()]
+
+
+def main() -> None:
+    write_metadata(
+        ingest_name="kg-phenio",
+        source_versions=get_source_versions(),
+        transform_paths=transform_files(),
+        artifacts=["merged-kg.tar.gz"],
+        output_dir=REPO_DIR / "output",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/versions.py
+++ b/versions.py
@@ -1,0 +1,130 @@
+"""Upstream source version fetcher for kg-phenio.
+
+kg-phenio merges phenio.json with two upheno SSSOM mappings. The receipt
+nests phenio's per-ontology versions (read from phenio's `phenio-upstream-
+versions.tsv` release asset) under a phenio "build" entry; the two upheno
+mapping files appear as peer leaves at the kg-phenio level.
+
+In local development against an unreleased phenio checkout, set
+`PHENIO_MANIFEST_PATH` to point at the local TSV (e.g.
+`../phenio/src/ontology/phenio-upstream-versions.tsv`). In CI / Jenkins the
+manifest is fetched from phenio's latest GitHub release.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from kozahub_metadata_schema import (
+    now_iso,
+    version_from_github_release,
+    version_from_http_last_modified,
+)
+
+
+PHENIO_REPO = "monarch-initiative/phenio"
+PHENIO_JSON_URL = f"https://github.com/{PHENIO_REPO}/releases/latest/download/phenio.json"
+PHENIO_MANIFEST_URL = f"https://github.com/{PHENIO_REPO}/releases/latest/download/phenio-upstream-versions.tsv"
+
+UPHENO_CROSS_URL = (
+    "https://data.monarchinitiative.org/mappings/latest/upheno-cross-species.sssom.tsv"
+)
+UPHENO_SPECIES_IND_URL = (
+    "https://data.monarchinitiative.org/mappings/latest/upheno-species-independent.sssom.tsv"
+)
+
+# Match the date segment in version IRIs. Most ontologies put the date under
+# `/releases/YYYY-MM-DD/` (CHEBI, MONDO, RO, …) but BFO uses `/YYYY-MM-DD/`
+# directly without the `releases/` prefix, so match any path segment shaped
+# like a date.
+VERSION_IRI_DATE = re.compile(r"/(\d{4}-\d{2}-\d{2})/")
+
+
+def _ontology_version(version_info: str, version_iri: str) -> str:
+    """Prefer the versionInfo column; fall back to the date in versionIRI."""
+    vi = (version_info or "").strip()
+    if vi:
+        return vi
+    m = VERSION_IRI_DATE.search(version_iri or "")
+    if m:
+        return m.group(1)
+    return "unknown"
+
+
+def _fetch_phenio_manifest(timeout: float = 10.0) -> str:
+    """Fetch phenio-upstream-versions.tsv. Raises on failure."""
+    override = os.environ.get("PHENIO_MANIFEST_PATH")
+    if override:
+        text = Path(override).read_text()
+        if not text.strip():
+            raise RuntimeError(f"PHENIO_MANIFEST_PATH={override} is empty")
+        return text
+
+    import requests
+
+    r = requests.get(PHENIO_MANIFEST_URL, allow_redirects=True, timeout=timeout)
+    r.raise_for_status()
+    if not r.text.strip():
+        raise RuntimeError(f"{PHENIO_MANIFEST_URL} returned empty body")
+    return r.text
+
+
+def _phenio_ontology_leaves(tsv_text: str) -> list[dict[str, Any]]:
+    leaves: list[dict[str, Any]] = []
+    for row in csv.DictReader(tsv_text.splitlines(), delimiter="\t"):
+        source = (row.get("source") or "").strip()
+        if not source:
+            continue
+        version_iri = (row.get("versionIRI") or "").strip()
+        leaves.append(
+            {
+                "id": f"infores:{source}",
+                "name": source.upper(),
+                "urls": [version_iri] if version_iri else [],
+                "version": _ontology_version(row.get("versionInfo", ""), version_iri),
+                "version_method": "owl_version_iri",
+            }
+        )
+    return leaves
+
+
+def get_source_versions() -> list[dict[str, Any]]:
+    now = now_iso()
+
+    # Phenio nested-build entry.
+    phenio_version, phenio_method = version_from_github_release(PHENIO_REPO)
+    manifest = _fetch_phenio_manifest()
+    phenio_entry: dict[str, Any] = {
+        "id": "phenio",
+        "name": "PHENIO",
+        "urls": [PHENIO_JSON_URL],
+        "version": phenio_version,
+        "version_method": phenio_method,
+        "retrieved_at": now,
+        "sources": _phenio_ontology_leaves(manifest),
+    }
+
+    sources: list[dict[str, Any]] = [phenio_entry]
+
+    # Upheno mappings — peer leaves at the kg-phenio level.
+    for url, infores_id, name in [
+        (UPHENO_CROSS_URL, "infores:upheno-cross-species", "UPheno cross-species mappings"),
+        (UPHENO_SPECIES_IND_URL, "infores:upheno-species-independent", "UPheno species-independent mappings"),
+    ]:
+        ver, method = version_from_http_last_modified(url)
+        sources.append(
+            {
+                "id": infores_id,
+                "name": name,
+                "urls": [url],
+                "version": ver,
+                "version_method": method,
+                "retrieved_at": now,
+            }
+        )
+
+    return sources


### PR DESCRIPTION
## Summary
kg-phenio now writes `output/release-metadata.yaml` describing the upstream sources consumed (phenio + the two upheno SSSOM mappings) and the artifacts produced (`merged-kg.tar.gz`). The receipt **nests phenio's own per-ontology versions** — read from phenio's [\`phenio-upstream-versions.tsv\`](https://github.com/monarch-initiative/phenio/blob/master/src/ontology/phenio-upstream-versions.tsv) release asset — as a \`Release\` inside the phenio entry, which itself sits under kg-phenio.

The receipt shape (excerpt):

\`\`\`yaml
source: kg-phenio
source_version: v2026-04-14         # phenio's tag, used as the primary upstream version
build_version: kg-phenio_v2026-04-14_<hash>_<biolink>
sources:
  - id: phenio
    name: PHENIO
    version: v2026-04-14
    version_method: github_release_api
    sources:
      - {id: infores:bfo,    version: 2019-08-26, version_method: owl_version_iri, urls: [...]}
      - {id: infores:chebi,  version: 2026-04-20, version_method: owl_version_iri, urls: [...]}
      - {id: infores:mondo,  version: ..., ...}
      # ~20 ontologies from phenio-upstream-versions.tsv
  - {id: infores:upheno-cross-species, ...}
  - {id: infores:upheno-species-independent, ...}
artifacts:
  - {path: merged-kg.tar.gz, sha256: ...}
\`\`\`

When monarch-ingest's aggregator picks this up (follow-up PR), HP/MONDO/CHEBI/etc. versions in monarch-kg's receipt trace back through \`kg-phenio → phenio → infores:<ontology>\`, full provenance preserved.

## Files
- **\`versions.py\`** (top-level, outside the \`kg_phenio/\` package so the metadata script doesn't pull in kgx via package init): \`get_source_versions()\` builds the nested phenio \`Release\` plus the two upheno peer leaves.
- **\`scripts/write_metadata.py\`**: standard kozahub-metadata-schema wrapper.
- **\`pyproject.toml\`**: \`kozahub-metadata-schema\` git dep.
- **\`Jenkinsfile\`**: new \`Metadata\` stage between Merge and Publish; the file is included in the s3 sync alongside the KG tarball.

## Test plan
- [x] Local dry run with phenio's manifest from an unreleased checkout: \`PHENIO_MANIFEST_PATH=../phenio/src/ontology/phenio-upstream-versions.tsv python scripts/write_metadata.py\` produces a valid receipt with all 6 ontologies (bfo/bspo/chebi/monochrom/pato/ro) showing real versions, plus the upheno mappings with \`http_last_modified\` versions.
- [ ] First production Jenkins build of kg-phenio after merge — confirms the Metadata stage runs and the file lands in s3.

## Notes
- The next phenio release will publish \`phenio-upstream-versions.tsv\` (\`RELEASE_ASSETS\` in \`phenio.Makefile\` already references it). Until then the production fetch will 404 and the \`Metadata\` stage will fail — by design (we'd rather notice loudly than silently emit an empty manifest).
- Companion PR coming on monarch-ingest to support a non-default metadata URL so kg-phenio's receipt (which lives at \`https://kg-hub.berkeleybop.io/kg-phenio/current/release-metadata.yaml\`, not a GitHub release) can be fetched by \`ingest download-release-metadata\`.