### PR TITLE
normalize.py: use merged.monarch context (fixes FBbt/WBbt prefix uppercasing)

### DIFF
--- a/kg_phenio/normalize.py
+++ b/kg_phenio/normalize.py
@@ -12,13 +12,23 @@ def normalize() -> None:
         None
 
     """
+    # Use the Monarch-specific `merged.monarch` context from prefixmaps as
+    # the single source of CURIE↔IRI conventions. The previous
+    # `["obo", "bioregistry.upper"]` pair interacted with universalizer's
+    # lowercased-reverse-IRI logic in `make_id_maps` and was producing
+    # all-uppercase prefix casings for OBO mixed-case anatomies (FBbt →
+    # FBBT, WBbt → WBBT). That dropped ~503k Drosophila + C. elegans
+    # gene-expression edges to dangling in the 2026-06-03 monarch-kg build
+    # (the entire shortfall on `alliance_gene_to_expression_edges`).
+    # `merged.monarch` is also what monarch-app's `curie_service.py` uses,
+    # so the whole stack is now aligned.
     print("Normalizing nodes and categories...")
     clean_and_normalize_graph(
         filepath="data/merged/",
         compressed=False,
         maps=[],
         update_categories=True,
-        contexts=["obo", "bioregistry.upper"],
+        contexts=["merged.monarch"],
         namespace_cat_map="",
         oak_lookup=False,
     )


### PR DESCRIPTION
## Summary

Swap the `clean_and_normalize_graph` `contexts` argument from `[\"obo\", \"bioregistry.upper\"]` to a single `[\"merged.monarch\"]`. Fixes a CURIE-casing bug where OBO mixed-case anatomy prefixes (FBbt, WBbt) were being emitted as all-uppercase (FBBT, WBBT) in `merged-kg_nodes.tsv`.

## Why the existing code produces uppercase

The two-context combination of `\"obo\"` + `\"bioregistry.upper\"` is fed to `universalizer.norm.clean_and_normalize_graph`, which builds reverse-IRI maps in `make_id_maps`:

```python
all_reverse_contexts = {val: key for key, val in all_contexts.items()}
all_reverse_contexts_lc = {val.lower(): key for key, val in all_contexts.items()}
all_reverse_contexts.update(all_reverse_contexts_lc)
iri_converter = Converter.from_reverse_prefix_map(all_reverse_contexts)
```

That lowercased-reverse-IRI key, merged on top of the canonical map, plus the two-context overlap, leaves room for non-canonical CURIEs to win on round-trips for OBO prefixes that have non-default casing — specifically `FBbt:` and `WBbt:`.

## Why a single \"merged.monarch\" context fixes it

`merged.monarch` is a single-context prefixmap (16,972 entries, same data as `merged` with a Monarch-specific label) that has one canonical IRI prefix per CURIE. With only one entry per IRI in the reverse map, the lowercased synonym can't override anything; the canonical case wins.

Verified locally — `http://purl.obolibrary.org/obo/FBbt_00000001` compresses to `FBbt:00000001` and `http://purl.obolibrary.org/obo/WBbt_0000001` compresses to `WBbt:0000001` under `merged.monarch`, as do all the other prefixes monarch-app exercises.

## Why this matters in practice

The 2026-06-03 monarch-kg release lost **504,820 alliance gene-expression edges** to the dangling pile — essentially the entire shortfall observed on `alliance_gene_to_expression_edges` (1.45M vs 1.9M expected). Investigation showed 99.7% are anatomy-side missing, and 100% of those (503,187) are FBbt + WBbt — exactly the two prefixes affected by this casing bug.

| missing namespace | dangling edges | species |
|---|---|---|
| `FBbt` | 397,914 | Drosophila melanogaster |
| `WBbt` | 105,273 | C. elegans |

After this PR ships and monarch-ingest picks up the next kg-phenio release, those edges resolve natively without any monarch-ingest-side workaround.

## Related

- **monarch-initiative/monarch-app#1319** — tracking issue with the full investigation.
- **monarch-initiative/monarch-app#1320** — companion PR aligning monarch-app's `curie_service.py` on `merged.monarch` so the whole Monarch stack uses one curated CURIE convention.