### PR TITLE
Recover OBO idspaces so phenio node categories survive kgx contraction

### DIFF
--- a/kg_phenio/transform_utils/phenio/phenio_node_sources.py
+++ b/kg_phenio/transform_utils/phenio/phenio_node_sources.py
@@ -9,6 +9,7 @@ from koza.cli_utils import get_koza_app  # type: ignore
 from pydantic import Field
 
 from kg_phenio.transform_utils.sources import BAD_PREFIXES, NODE_SOURCES
+from kg_phenio.utils.transform_utils import split_generic_obo_curie
 
 source_name = "phenio_node_sources"
 
@@ -93,11 +94,13 @@ while (row := koza_app.get_row()) is not None:
         if node_curie_prefix == "FlyBase":  # Look at ID to get the category
             if node_curie_value.startswith("FBgn"):
                 node_curie_prefix = "FBgn"
-        if node_curie_prefix == "OBO":  # Look at ID to get the category
-            if node_curie_value.startswith("XPO"):
-                node_curie_prefix = "XPO"
-            elif node_curie_value.startswith("HsapDv"):
-                node_curie_prefix = "HsapDv"
+        # Ontologies with no explicit entry in kgx's prefix map arrive collapsed
+        # onto the generic OBO prefix (OBO:DDPHENO_0000001), which has no category
+        # of its own. Recover the idspace so the lookup below finds one. The node ID
+        # itself is left as-is; universalizer rewrites it during normalization, and
+        # it has to stay in step with the edge endpoints written by
+        # phenio_edge_sources.py.
+        node_curie_prefix, _ = split_generic_obo_curie(node_curie_prefix, node_curie_value)
         # Defensive: prefixes that aren't in our NODE_SOURCES map keep
         # whatever category kgx assigned. Previously these would have arrived
         # as URIs and been filtered out via BAD_PREFIXES; with the kgx

--- a/kg_phenio/utils/transform_utils.py
+++ b/kg_phenio/utils/transform_utils.py
@@ -5,7 +5,7 @@ import os
 import re
 import shutil
 import zipfile
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from tqdm import tqdm  # type: ignore
 
@@ -212,6 +212,37 @@ def guess_bl_category(identifier: str) -> str:
     else:
         category = "biolink:NamedThing"
     return category
+
+
+# A local part of the form <idspace>_<localid>, e.g. DDPHENO_0000001. The idspace
+# must be a bare alphanumeric OBO idspace, so relation IRIs (fbbt#has_function_in),
+# sub-namespaces (go/extensions/ro_0002092) and multi-underscore IDs
+# (FBbt_root_00000000) do not match.
+GENERIC_OBO_LOCAL_ID = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_([^_#]+)$")
+
+
+def split_generic_obo_curie(prefix: str, local_id: str) -> Tuple[str, str]:
+    """Recover the real idspace from a CURIE collapsed onto the generic OBO prefix.
+
+    kgx's default prefix map carries a generic OBO -> http://purl.obolibrary.org/obo/
+    entry, so any OBO ontology without its own entry in that map contracts to
+    OBO:DDPHENO_0000001 rather than DDPHENO:0000001. Prefix-keyed lookups then see
+    "OBO" instead of the ontology. Splitting the local part restores the idspace,
+    preserving its case, so FBbt stays FBbt.
+
+    Only well-formed <idspace>_<localid> local parts are split -- a subset of what
+    universalizer's obo_handle() rewrites during normalization. Anything declined
+    here keeps the generic OBO prefix, which is the behaviour it already had.
+
+    :param prefix: the CURIE prefix
+    :param local_id: everything after the first colon
+    :return: (prefix, local_id), unchanged unless prefix is OBO and splittable
+    """
+    if prefix == "OBO":
+        match = GENERIC_OBO_LOCAL_ID.match(local_id)
+        if match:
+            return match.group(1), match.group(2)
+    return prefix, local_id
 
 
 def collapse_uniprot_curie(uniprot_curie: str) -> str:

--- a/tests/test_transform_utils.py
+++ b/tests/test_transform_utils.py
@@ -3,7 +3,12 @@ import unittest
 
 from parameterized import parameterized
 
-from kg_phenio.utils.transform_utils import collapse_uniprot_curie, guess_bl_category
+from kg_phenio.transform_utils.sources import NODE_SOURCES
+from kg_phenio.utils.transform_utils import (
+    collapse_uniprot_curie,
+    guess_bl_category,
+    split_generic_obo_curie,
+)
 
 
 class TestTransformUtils(unittest.TestCase):
@@ -33,3 +38,53 @@ class TestTransformUtils(unittest.TestCase):
     def test_collapse_uniprot_curie(self, curie, collapsed_curie):
         """Test collapsing Uniprot protein CURIEs."""
         self.assertEqual(collapsed_curie, collapse_uniprot_curie(curie))
+
+
+class TestGenericOboCurie(unittest.TestCase):
+    """Test recovery of idspaces from CURIEs collapsed onto the generic OBO prefix."""
+
+    @parameterized.expand(
+        [
+            # Splittable: <idspace>_<localid>, with the idspace's case preserved.
+            ["OBO", "DDPHENO_0000001", "DDPHENO", "0000001"],
+            ["OBO", "FBbt_00000001", "FBbt", "00000001"],
+            ["OBO", "HsapDv_0000001", "HsapDv", "0000001"],
+            # Not splittable: these keep the generic OBO prefix.
+            ["OBO", "FBbt_root_00000000", "OBO", "FBbt_root_00000000"],
+            ["OBO", "fbbt#has_function_in", "OBO", "fbbt#has_function_in"],
+            ["OBO", "go/extensions/ro_0002092", "OBO", "go/extensions/ro_0002092"],
+            ["OBO", "ObsoleteClass", "OBO", "ObsoleteClass"],
+            # Every other prefix passes through untouched.
+            ["FYPO", "0000001", "FYPO", "0000001"],
+            ["HGNC", "1234", "HGNC", "1234"],
+        ]
+    )
+    def test_split_generic_obo_curie(self, prefix, local_id, exp_prefix, exp_local_id):
+        """Test splitting a generic OBO CURIE into its real idspace."""
+        self.assertEqual((exp_prefix, exp_local_id), split_generic_obo_curie(prefix, local_id))
+
+    @parameterized.expand(
+        [
+            ["OBO:DDPHENO_0000001", "PhenotypicFeature"],
+            ["OBO:FBbt_00000001", "AnatomicalEntity"],
+            ["OBO:WBbt_0005733", "AnatomicalEntity"],
+            ["OBO:EMAPA_16040", "AnatomicalEntity"],
+            ["OBO:ZFA_0000001", "AnatomicalEntity"],
+            ["OBO:XAO_0000001", "AnatomicalEntity"],
+            ["OBO:ZFS_0000001", "LifeStage"],
+            ["OBO:CHR_0000001", "MolecularEntity"],
+            ["OBO:XPO_0000001", "PhenotypicFeature"],
+            ["OBO:HsapDv_0000001", "LifeStage"],
+        ]
+    )
+    def test_node_category_found_by_idspace(self, curie, category):
+        """Test that a node category is reachable when kgx collapses the prefix.
+
+        kgx contracts OBO ontologies missing from its prefix map to
+        OBO:<idspace>_<localid>. NODE_SOURCES has no category under "OBO", so
+        without the split these nodes keep the generic biolink:NamedThing --
+        which is what left ~52k phenio nodes untyped from kg-phenio 20260603 on.
+        """
+        prefix, local_id = curie.split(":", 1)
+        prefix, _ = split_generic_obo_curie(prefix, local_id)
+        self.assertEqual(category, NODE_SOURCES[prefix][1])


### PR DESCRIPTION
## Problem

Every monarch-kg release from `2026-06-03` on types DDPHENO (Dictyostelium phenotype) terms as `biolink:NamedThing` instead of `biolink:PhenotypicFeature`. It isn't just DDPHENO — 51,971 phenio nodes across eight ontologies lost their category between kg-phenio `20260508` and `20260603`:

| prefix | was | now | n |
|---|---|---|---|
| DDPHENO | `biolink:PhenotypicFeature` | `biolink:NamedThing` | 1,373 |
| FBbt | `biolink:AnatomicalEntity` | `biolink:NamedThing` | 28,766 |
| EMAPA | `biolink:AnatomicalEntity` | `biolink:NamedThing` | 8,853 |
| WBbt | `biolink:AnatomicalEntity` | `biolink:NamedThing` | 7,555 |
| ZFA | `biolink:AnatomicalEntity` | `biolink:NamedThing` | 3,231 |
| XAO | `biolink:AnatomicalEntity` | `biolink:NamedThing` | 1,830 |
| CHR | `biolink:MolecularEntity` | `biolink:NamedThing` | 309 |
| ZFS | `biolink:LifeStage` | `biolink:NamedThing` | 54 |

Downstream consumers that gate on category silently lose data. Anything selecting `biolink:PhenotypicFeature` neighbours drops Dictyostelium entirely, despite its 2,716 `has_phenotype` edges being present and intact.

## Cause

kgx 2.7.0 made `TsvSource.set_prefix_map` additive rather than destructive, restoring kgx's 631-entry default prefix map for every source inheriting it — including `ObographSource`. That map carries a generic `OBO -> http://purl.obolibrary.org/obo/` entry and has no per-ontology entry for the eight ontologies above, so the generic prefix now wins IRI contraction:

```
kgx 2.6.0:  http://purl.obolibrary.org/obo/DDPHENO_0000001  ->  DDPHENO:0000001
kgx 2.7.0:  http://purl.obolibrary.org/obo/DDPHENO_0000001  ->  OBO:DDPHENO_0000001
```

(FYPO, HP, MP, MONDO, CHEBI, UBERON and friends are unaffected — they have their own entries.)

`phenio_node_sources.py` looks the category up by CURIE prefix. `NODE_SOURCES` has no category under `"OBO"`, so the generic `OntologyClass -> NamedThing` remap is never upgraded to the specific category. The pre-existing `if node_curie_prefix == "OBO"` branch recovered only XPO and HsapDv — the same bug class, patched by hand twice.

## Fix

`split_generic_obo_curie()` splits the local part back into its idspace before the lookup, replacing the two special cases with the general rule. Case is preserved, so `FBbt` stays `FBbt`. Only well-formed `<idspace>_<localid>` local parts are split, so relation IRIs (`OBO:fbbt#has_function_in`), sub-namespaces (`OBO:go/extensions/ro_0002092`) and multi-underscore IDs (`OBO:FBbt_root_00000000`) keep the behaviour they already have.

**Node IDs are deliberately left as-is.** universalizer rewrites them during normalization, and they have to stay in step with the edge endpoints `phenio_edge_sources.py` writes — rewriting them here alone would leave node IDs at `FBbt:` while universalizer's `obo_handle()` still uppercased the edge endpoints to `FBBT:`, sending every FBbt/WBbt edge to the dangling pile.

## Verification

Driven through the real koza transform (`transform_source` with `phenio_node_sources.yaml`) over a fixture built from real kgx 2.7.0 obojson output:

```
OBO:DDPHENO_0000001           biolink:PhenotypicFeature  infores:ddpheno
OBO:FBbt_00000001             biolink:AnatomicalEntity   infores:fbbt
OBO:WBbt_0005733              biolink:AnatomicalEntity   infores:wbbt
OBO:EMAPA_16040               biolink:AnatomicalEntity   infores:emapa
OBO:ZFA_0000001               biolink:AnatomicalEntity   infores:zfa
OBO:XAO_0000001               biolink:AnatomicalEntity   infores:xao
OBO:ZFS_0000001               biolink:LifeStage          infores:zfs
OBO:CHR_0000001               biolink:MolecularEntity    infores:chr
OBO:OBA_0000001               biolink:NamedThing         infores:oba   # no NODE_SOURCES category, unchanged
OBO:FBbt_root_00000000        biolink:NamedThing         infores:obo   # declined
OBO:fbbt#has_function_in      biolink:NamedThing         infores:obo   # declined
OBO:go/extensions/ro_0002092  biolink:NamedThing         infores:obo   # declined
FYPO / HP / MONDO / HGNC URI                                          # controls, unchanged
```

Same fixture on `master` vs this branch: the delta is exactly eight category changes and nine `infores` changes. Identical IDs, identical header, same row count in and out. Every recovered category matches what `20260508` shipped, so this restores the pre-regression state rather than introducing new typings.

The new tests fail without the fix (all 10 category cases and 3 split cases). Full suite passes, `ruff check kg_phenio tests` clean.

## Downstream checks

- `BAD_PREFIXES` is tested before the split, on the un-recovered prefix, so recovery can't newly exclude a node.
- universalizer's `update_categories` overwrites only when the nodefile category is `""` or `biolink:OntologyClass`, so the recovered specific categories survive normalization; `namespace_cat_map` is empty, so there's no ns_map path either.
- Its `RETAINED_CAT_LIST` short-circuit (PhenotypicFeature subjects skip the `biolink:category` edge loop, including its `remove_edges` bookkeeping) is inert here: `phenio_edge_sources.py` already drops `biolink:category` predicates, so no such edge reaches the merged edge file.
- In monarch-ingest, all four recovered categories are `named thing` descendants, so `transform_phenio`'s `valid_node_categories` filter keeps them; nothing there branches on `NamedThing`, and `qc_expect.yaml` asserts only total phenio node/edge minimums, which don't change.
- The deleted XPO and HsapDv special cases were already dead code — both prefixes have their own entries in kgx's map, so they contract directly and never reached that branch. Kept as test cases so the general rule can't silently lose them.

## Out of scope

- **`FBbt` -> `FBBT` / `WBbt` -> `WBBT` uppercasing.** universalizer's `obo_handle()` uppercases the prefix unconditionally, so any `OBO:`-collapsed mixed-case idspace comes out wrong. That is the actual source of the casing problem — #201 targeted the prefixmaps context and the `20260808` release still ships `FBBT:`. Fixing it means rewriting IDs in the node and edge transforms in lockstep; monarch-ingest currently normalizes the case on its side. Worth a follow-up.
- **`phenio_edge_sources.py`'s own OBO handling** (`(subject.split("_"))[0][4:]`). It only feeds the edge `primary_knowledge_source`, and switching it to the shared helper would change infores values for relation-IRI subjects. Left alone.
- **kgx itself.** Preferring the most specific matching prefix over the generic `OBO:` one would fix this for every kgx consumer, but it shifts IDs broadly and belongs upstream on its own release cycle. Happy to open an issue there.
